### PR TITLE
fix: replaced nodemailer with resend

### DIFF
--- a/env.example
+++ b/env.example
@@ -4,9 +4,9 @@ MONGODB_URI=mongodb+srv://username:password@cluster.mongodb.net/
 MONGODB_DB=makerspace
 
 # Email
-# If using Gmail/SMTP
-EMAIL_USER=you@example.com
-EMAIL_PASSWORD=your-gmail-app-password
+# Resend
+RESEND_API_KEY=your-resend-api-key
+EMAIL_FROM="delivered@resend.dev"
 
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
         "jsonwebtoken": "^9.0.2",
         "mongodb": "^6.3.0",
         "next": "15.4.6",
-        "nodemailer": "^7.0.5",
         "react": "19.1.0",
-        "react-dom": "19.1.0"
+        "react-dom": "19.1.0",
+        "resend": "^6.1.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -4904,15 +4904,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/nodemailer": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.5.tgz",
-      "integrity": "sha512-nsrh2lO3j4GkLLXoeEksAMgAOqxOv6QumNRVQTJwKH4nuiww6iC2y7GyANs9kRAxCexg3+lTWM3PZ91iLlVjfg==",
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -5330,6 +5321,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resend": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.1.0.tgz",
+      "integrity": "sha512-H0cJI2pcLk5/dGwyvZUHu+O7X/q6arvc40EWm+pRPuy+PSWojH5utZtmDBUZ2L0+gVwYZiWs6y2lw6GQA1z1rg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@react-email/render": "^1.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
       }
     },
     "node_modules/resolve": {

--- a/package.json
+++ b/package.json
@@ -20,9 +20,9 @@
     "jsonwebtoken": "^9.0.2",
     "mongodb": "^6.3.0",
     "next": "15.4.6",
-    "nodemailer": "^7.0.5",
     "react": "19.1.0",
-    "react-dom": "19.1.0"
+    "react-dom": "19.1.0",
+    "resend": "^6.1.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -61,7 +61,7 @@ async function refreshAccessToken() {
 
 
 
-// Email utility functions using Nodemailer
+// Email utility functions 
 export async function sendBookingConfirmationEmail( bookingDetails) {
   try {
     // Get current theme from cookies


### PR DESCRIPTION
## Replace Nodemailer with Resend (custom domain)

- #30 
- Switched email transport from Nodemailer (Gmail/SMTP) to Resend via verified custom domain.
- Preserved existing HTML templates and theme parameters; only transport changed.

### Changes
- `src/app/api/auth/forgot-password/route.js`: Resend for reset emails; token expiry 10 minutes.
- `src/app/api/auth/create-user/route.js`: Resend for admin invites; token expiry 48 hours.
- `src/app/api/email/route.js`: Resend for booking confirmation and welcome emails.
- `makerspaceapp/env.example`: replaced SMTP vars with `RESEND_API_KEY` and `EMAIL_FROM`.

### New environment variables
- `RESEND_API_KEY`: Resend API key.
- `EMAIL_FROM`: e.g. `test@example.com` (must be verified in Resend).

### Setup
1. Add env:
   - `RESEND_API_KEY=...`
   - `EMAIL_FROM="test@example.com"`
2. Resend dashboard:
   - Verify custom domain (DNS) and sender.
